### PR TITLE
Closes #8 - HTTPRequestsPostSignal block can be configured to emit a sig...

### DIFF
--- a/http_requests_post_signal_block.py
+++ b/http_requests_post_signal_block.py
@@ -12,7 +12,6 @@ from nio.metadata.properties.list import ListProperty
 from enum import Enum
 import requests
 import json
-from simplejson.scanner import JSONDecodeError
 
 
 class ResponseSignal(Signal):
@@ -130,7 +129,7 @@ class HTTPRequestsPostSignal(Block):
                         result = sigs
                 self._logger.warning("Request body could not be parsed into "
                                      "Signal(s): {}".format(rjson))
-            except JSONDecodeError:
+            except ValueError:
                 if not self.require_json:
                     result = [ResponseSignal({'raw': r.text})]
                 else:

--- a/http_requests_post_signal_block.py
+++ b/http_requests_post_signal_block.py
@@ -12,6 +12,7 @@ from nio.metadata.properties.list import ListProperty
 from enum import Enum
 import requests
 import json
+from simplejson.scanner import JSONDecodeError
 
 
 class ResponseSignal(Signal):
@@ -74,6 +75,7 @@ class HTTPRequestsPostSignal(Block):
         title='HTTP Method'
     )
     headers = ListProperty(Header, title="Headers")
+    require_json = BoolProperty(title="Require JSON Response", default=False)
 
     def process_signals(self, signals):
         new_signals = []
@@ -115,33 +117,41 @@ class HTTPRequestsPostSignal(Block):
             self._logger.warning("Bad Http Request: {0}".format(e))
             return
         if 200 <= r.status_code < 300:
+            result = None
             try:
                 rjson = r.json()
                 if isinstance(rjson, dict):
-                    sig = ResponseSignal(rjson)
-                    return [sig]
+                    result = [ResponseSignal(rjson)]
                 if isinstance(rjson, list):
                     sigs = []
                     for s in rjson:
                         sigs.append(ResponseSignal(s))
                     if sigs:
-                        return sigs
+                        result = sigs
                 self._logger.warning("Request body could not be parsed into "
                                      "Signal(s): {}".format(rjson))
-                return None
+            except JSONDecodeError:
+                if not self.require_json:
+                    result = [ResponseSignal({'raw': r.text})]
+                else:
+                    self._logger.warning(
+                        "Request was successful, but response was not "
+                        "valid JSON. No ResponseSignal was created."
+                    )
             except Exception as e:
                 self._logger.warning(
-                    "Request was successfull but "
+                    "Request was successful but "
                     "failed to create ResponseSignal: {}".format(e)
                 )
-                return
+            finally:
+                return result
         else:
-            self._logger.warning("{} request to {} returned with "
-                                    "response code: {}".format(
-                                        self.http_method,
-                                        url,
-                                        r.status_code
-                                    )
+            self._logger.warning(
+                "{} request to {} returned with response code: {}".format(
+                    self.http_method,
+                    url,
+                    r.status_code
+                )
             )
 
     def _get(self, url, auth, payload, headers):

--- a/tests/test_http_requests_post_signal_block.py
+++ b/tests/test_http_requests_post_signal_block.py
@@ -4,7 +4,6 @@ from nio.common.signal.base import Signal
 from unittest.mock import MagicMock
 from nio.modules.threading import Event
 from ..http_requests_post_signal_block import HTTPRequestsPostSignal
-from simplejson.scanner import JSONDecodeError
 
 
 def create_signal(val1='value1', val2='value2'):
@@ -56,7 +55,7 @@ class TestHTTPRequestsPostSignal(NIOBlockTestCase):
                 self.text = 'not json'
             def json(self):
                 # a signal will be notified with this response body
-                raise JSONDecodeError('fail', 'data', 1)
+                raise ValueError('fail', 'data', 1)
         block._get = MagicMock(return_value=Resp(200))
         config = {
             "log_level": "WARNING",
@@ -69,7 +68,7 @@ class TestHTTPRequestsPostSignal(NIOBlockTestCase):
         self.assertTrue(block._get.called)
         self.assertEqual(self.last_notified[0].raw, 'not json')
         block.stop()
-        
+
     def test_get_with_non_json_resp_fail(self):
         url = "http://httpbin.org/get"
         block = self.BLOCK()
@@ -79,7 +78,7 @@ class TestHTTPRequestsPostSignal(NIOBlockTestCase):
                 self.status_code = status_code
             def json(self):
                 # a signal will be notified with this response body
-                raise JSONDecodeError
+                raise ValueError
         block._get = MagicMock(return_value=Resp(200))
         config = {
             "http_method": "GET",


### PR DESCRIPTION
...nal containing raw response data if json parse fails

Signed-off-by: Oren Leiman <oleiman@neutral.io>